### PR TITLE
Disable Coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
-orbs:
-  coveralls: coveralls/coveralls@1.0.6
+# orbs:
+#   coveralls: coveralls/coveralls@1.0.6
 jobs:
   build:
     docker:
@@ -41,23 +41,24 @@ jobs:
       #     command: |
       #       sudo apt install -y libtinfo5
       #       pipenv run pio check --fail-on-defect high -e native
-      - run:
-          name: Coverage
-          command: |
-            mkdir -p .coverage/input .coverage/output
-            shopt -s globstar
-            cp .pio/**/*.gcno .coverage/input || :
-            cp .pio/**/*.gcda .coverage/input || :
-            pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/output/coverage.html
-            sudo apt install lcov
-            lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/*" --exclude "*/Common/lib/MbedMock/*" --exclude "*/test/*" --output-file .coverage/input/coverage.info
+      # Disable code coverage checks since we are no longer aiming for 100% coverage
+      # - run:
+      #     name: Coverage
+      #     command: |
+      #       mkdir -p .coverage/input .coverage/output
+      #       shopt -s globstar
+      #       cp .pio/**/*.gcno .coverage/input || :
+      #       cp .pio/**/*.gcda .coverage/input || :
+      #       pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/output/coverage.html
+      #       sudo apt install lcov
+      #       lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/*" --exclude "*/Common/lib/MbedMock/*" --exclude "*/test/*" --output-file .coverage/input/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
             - ~/.platformio/cache
             - .coverage
           key: platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci/config.yml" }}
-      - store_artifacts:
-          path: .coverage/output
-      - coveralls/upload:
-          path_to_lcov: .coverage/input/coverage.info
+      # - store_artifacts:
+      #     path: .coverage/output
+      # - coveralls/upload:
+      #     path_to_lcov: .coverage/input/coverage.info


### PR DESCRIPTION
This PR disables the Coveralls check since we are no longer aiming for 100% code coverage.