### PR TITLE
Fix pipenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             sudo apt update
             pip install --upgrade pipenv
-            pipenv install
+            pipenv --python 3.9.8 install
             pipenv run pio update
             pipenv run pio platform install native
       - run:


### PR DESCRIPTION
This changes the python version used by pipenv in our CircleCI script. The specific version should not matter, but the default was not working for some reason.