### PR TITLE
Added to can struct header files

### DIFF
--- a/Common/lib/CANStructs/ECUCANStructs.h
+++ b/Common/lib/CANStructs/ECUCANStructs.h
@@ -29,7 +29,7 @@ typedef struct ECUMotorCommands : CANStruct, BitprotoECUMotorCommands {
 typedef struct ECUPowerAuxCommands : CANStruct, BitprotoECUPowerAuxCommands {
     void serialize(CANMessage *message) {
         EncodeBitprotoECUPowerAuxCommands(this, message->data);
-        message->len = BYTES_LENGTH_BITPROTO_ECU_MOTOR_COMMANDS;
+        message->len = BYTES_LENGTH_BITPROTO_ECU_POWER_AUX_COMMANDS;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/ECUCANStructs.h
+++ b/Common/lib/CANStructs/ECUCANStructs.h
@@ -8,6 +8,7 @@
 typedef struct ECUMotorCommands : CANStruct, BitprotoECUMotorCommands {
     void serialize(CANMessage *message) {
         EncodeBitprotoECUMotorCommands(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_ECU_MOTOR_COMMANDS;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/ECUCANStructs.h
+++ b/Common/lib/CANStructs/ECUCANStructs.h
@@ -29,6 +29,7 @@ typedef struct ECUMotorCommands : CANStruct, BitprotoECUMotorCommands {
 typedef struct ECUPowerAuxCommands : CANStruct, BitprotoECUPowerAuxCommands {
     void serialize(CANMessage *message) {
         EncodeBitprotoECUPowerAuxCommands(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_ECU_MOTOR_COMMANDS;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/MotorControllerCANStructs.h
+++ b/Common/lib/CANStructs/MotorControllerCANStructs.h
@@ -42,6 +42,7 @@ typedef struct MotorControllerPowerStatus : CANStruct,
                                             BitprotoMotorControllerPowerStatus {
     void serialize(CANMessage *message) {
         EncodeBitprotoMotorControllerPowerStatus(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_MOTOR_CONTROLLER_POWER_STATUS;
     }
 
     void deserialize(CANMessage *message) {
@@ -70,6 +71,7 @@ typedef struct MotorControllerDriveStatus : CANStruct,
                                             BitprotoMotorControllerDriveStatus {
     void serialize(CANMessage *message) {
         EncodeBitprotoMotorControllerDriveStatus(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_MOTOR_CONTROLLER_DRIVE_STATUS;
     }
 
     void deserialize(CANMessage *message) {
@@ -97,6 +99,7 @@ typedef struct MotorControllerDriveStatus : CANStruct,
 typedef struct MotorControllerError : CANStruct, BitprotoMotorControllerError {
     void serialize(CANMessage *message) {
         EncodeBitprotoMotorControllerError(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_MOTOR_CONTROLLER_ERROR;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/MotorControllerCANStructs.h
+++ b/Common/lib/CANStructs/MotorControllerCANStructs.h
@@ -15,6 +15,7 @@ typedef struct MotorControllerFrameRequest
       BitprotoMotorControllerFrameRequest {
     void serialize(CANMessage *message) {
         EncodeBitprotoMotorControllerFrameRequest(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_MOTOR_CONTROLLER_FRAME_REQUEST;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/PowerAuxBPSCANStructs.h
+++ b/Common/lib/CANStructs/PowerAuxBPSCANStructs.h
@@ -39,6 +39,7 @@ typedef struct BPSPackInformation : CANStruct, BitprotoBPSPackInformation {
 typedef struct BPSError : CANStruct, BitprotoBPSError {
     void serialize(CANMessage *message) {
         EncodeBitprotoBPSError(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_BPS_PACK_INFORMATION;
     }
 
     void deserialize(CANMessage *message) {
@@ -94,6 +95,7 @@ typedef struct BPSError : CANStruct, BitprotoBPSError {
 typedef struct BPSCellVoltage : CANStruct, BitprotoBPSCellVoltage {
     void serialize(CANMessage *message) {
         EncodeBitprotoBPSCellVoltage(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_BPS_CELL_VOLTAGE;
     }
 
     void deserialize(CANMessage *message) {
@@ -119,6 +121,7 @@ typedef struct BPSCellVoltage : CANStruct, BitprotoBPSCellVoltage {
 typedef struct BPSCellTemperature : CANStruct, BitprotoBPSCellTemperature {
     void serialize(CANMessage *message) {
         EncodeBitprotoBPSCellTemperature(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_BPS_CELL_TEMPERATURE;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/PowerAuxBPSCANStructs.h
+++ b/Common/lib/CANStructs/PowerAuxBPSCANStructs.h
@@ -39,7 +39,7 @@ typedef struct BPSPackInformation : CANStruct, BitprotoBPSPackInformation {
 typedef struct BPSError : CANStruct, BitprotoBPSError {
     void serialize(CANMessage *message) {
         EncodeBitprotoBPSError(this, message->data);
-        message->len = BYTES_LENGTH_BITPROTO_BPS_PACK_INFORMATION;
+        message->len = BYTES_LENGTH_BITPROTO_BPS_ERROR;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/PowerAuxBPSCANStructs.h
+++ b/Common/lib/CANStructs/PowerAuxBPSCANStructs.h
@@ -13,6 +13,7 @@
 typedef struct BPSPackInformation : CANStruct, BitprotoBPSPackInformation {
     void serialize(CANMessage *message) {
         EncodeBitprotoBPSPackInformation(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_BPS_PACK_INFORMATION;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/PowerAuxCANStructs.h
+++ b/Common/lib/CANStructs/PowerAuxCANStructs.h
@@ -8,6 +8,7 @@
 typedef struct PowerAuxError : CANStruct, BitprotoPowerAuxError {
     void serialize(CANMessage *message) {
         EncodeBitprotoPowerAuxError(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_POWER_AUX_ERROR;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/SolarCANStructs.h
+++ b/Common/lib/CANStructs/SolarCANStructs.h
@@ -8,6 +8,7 @@
 typedef struct SolarCurrent : CANStruct, BitprotoSolarCurrent {
     void serialize(CANMessage *message) {
         EncodeBitprotoSolarCurrent(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_SOLAR_CURRENT;
     }
 
     void deserialize(CANMessage *message) {

--- a/Common/lib/CANStructs/SolarCANStructs.h
+++ b/Common/lib/CANStructs/SolarCANStructs.h
@@ -24,6 +24,7 @@ typedef struct SolarCurrent : CANStruct, BitprotoSolarCurrent {
 typedef struct SolarVoltage : CANStruct, BitprotoSolarVoltage {
     void serialize(CANMessage *message) {
         EncodeBitprotoSolarVoltage(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_SOLAR_VOLTAGE;
     }
 
     void deserialize(CANMessage *message) {
@@ -43,6 +44,7 @@ typedef struct SolarVoltage : CANStruct, BitprotoSolarVoltage {
 typedef struct SolarTemp : CANStruct, BitprotoSolarTemp {
     void serialize(CANMessage *message) {
         EncodeBitprotoSolarTemp(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_SOLAR_TEMP;
     }
 
     void deserialize(CANMessage *message) {
@@ -61,6 +63,7 @@ typedef struct SolarTemp : CANStruct, BitprotoSolarTemp {
 typedef struct SolarPhoto : CANStruct, BitprotoSolarPhoto {
     void serialize(CANMessage *message) {
         EncodeBitprotoSolarPhoto(this, message->data);
+        message->len = BYTES_LENGTH_BITPROTO_SOLAR_PHOTO;
     }
 
     void deserialize(CANMessage *message) {


### PR DESCRIPTION
For example, added the following to each can struct header file. The one shown is for the solar board.
""
void serialize(CANMessage *message) {
        EncodeBitprotoSolarCurrent(this, message->data);
        message->len = BYTES_LENGTH_BITPROTO_SOLAR_CURRENT;
    }
""

