### PR TITLE
Motor CAN failure handling

### DIFF
--- a/ECU/src/main.cpp
+++ b/ECU/src/main.cpp
@@ -8,7 +8,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL              LOG_ERROR
+#define LOG_LEVEL              LOG_FATAL
 #define MAIN_LOOP_PERIOD       1s
 #define MOTOR_THREAD_PERIOD    10ms
 #define POWERAUX_THREAD_PERIOD 10ms

--- a/Motor/src/main.cpp
+++ b/Motor/src/main.cpp
@@ -14,6 +14,9 @@
 
 BufferedSerial device(USBTX, USBRX);
 
+EventQueue event_queue(32 * EVENTS_EVENT_SIZE);
+Thread event_thread;
+
 MotorCANInterface vehicle_can_interface(MAIN_CAN_RX, MAIN_CAN_TX);
 MotorControllerCANInterface motor_controller_can_interface(MTR_CTRL_CAN_RX,
                                                            MTR_CTRL_CAN_TX,
@@ -34,6 +37,8 @@ int main() {
     log_set_level(LOG_LEVEL);
     log_debug("Start main()");
 
+    event_thread.start(callback(&event_queue, &EventQueue::dispatch_forever));
+
     while (true) {
         check_motor_board();
         log_debug("Main thread loop");
@@ -44,8 +49,22 @@ int main() {
     }
 }
 
+Timeout ECUMotorCommands_timeout;
+
+// If we have not received an ECUMotorCommands struct in 100ms, we assume that
+// the CAN bus is down and set the throttle to 0.
+void handle_ECUMotorCommands_timeout() {
+    motor_interface.sendThrottle(0x000);
+}
+
 void MotorCANInterface::handle(ECUMotorCommands *can_struct) {
+    // Reset current timeout
+    ECUMotorCommands_timeout.detach();
+    // Set new timeout for 100ms from now
+    ECUMotorCommands_timeout.attach(event_queue.event(handle_ECUMotorCommands_timeout), 100ms);
+
     can_struct->log(LOG_INFO);
+
     motor_interface.sendIgnition(can_struct->motor_on);
     motor_interface.sendDirection(
         can_struct->forward_en); // TODO: verify motor controller will not allow
@@ -57,6 +76,7 @@ void MotorCANInterface::handle(ECUMotorCommands *can_struct) {
 void MotorControllerCANInterface::handle(
     MotorControllerPowerStatus *can_struct) {
     can_struct->log(LOG_INFO);
+
     vehicle_can_interface.send(can_struct);
     motor_state_tracker.setMotorControllerPowerStatus(*can_struct);
 }
@@ -64,12 +84,14 @@ void MotorControllerCANInterface::handle(
 void MotorControllerCANInterface::handle(
     MotorControllerDriveStatus *can_struct) {
     can_struct->log(LOG_INFO);
+
     vehicle_can_interface.send(can_struct);
     motor_state_tracker.setMotorControllerDriveStatus(*can_struct);
 }
 
 void MotorControllerCANInterface::handle(MotorControllerError *can_struct) {
     can_struct->log(LOG_INFO);
+
     vehicle_can_interface.send(can_struct);
     motor_state_tracker.setMotorControllerError(*can_struct);
 }

--- a/Motor/src/main.cpp
+++ b/Motor/src/main.cpp
@@ -9,7 +9,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL        LOG_ERROR
+#define LOG_LEVEL        LOG_FATAL
 #define MAIN_LOOP_PERIOD 100ms
 
 BufferedSerial device(USBTX, USBRX);

--- a/Motor/src/main.cpp
+++ b/Motor/src/main.cpp
@@ -37,9 +37,7 @@ Timeout ECUMotorCommands_timeout;
 
 // If we have not received an ECUMotorCommands struct in 100ms, we assume that
 // the CAN bus is down and set the throttle to 0.
-void handle_ECUMotorCommands_timeout() {
-    motor_interface.sendThrottle(0x000);
-}
+void handle_ECUMotorCommands_timeout() { motor_interface.sendThrottle(0x000); }
 
 int main() {
     log_set_level(LOG_LEVEL);
@@ -47,7 +45,8 @@ int main() {
 
     event_thread.start(callback(&event_queue, &EventQueue::dispatch_forever));
 
-    ECUMotorCommands_timeout.attach(event_queue.event(handle_ECUMotorCommands_timeout), 100ms);
+    ECUMotorCommands_timeout.attach(
+        event_queue.event(handle_ECUMotorCommands_timeout), 100ms);
 
     while (true) {
         check_motor_board();
@@ -63,7 +62,8 @@ void MotorCANInterface::handle(ECUMotorCommands *can_struct) {
     // Reset current timeout
     ECUMotorCommands_timeout.detach();
     // Set new timeout for 100ms from now
-    ECUMotorCommands_timeout.attach(event_queue.event(handle_ECUMotorCommands_timeout), 100ms);
+    ECUMotorCommands_timeout.attach(
+        event_queue.event(handle_ECUMotorCommands_timeout), 100ms);
 
     can_struct->log(LOG_INFO);
 

--- a/PowerAux/src/main.cpp
+++ b/PowerAux/src/main.cpp
@@ -7,7 +7,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL          LOG_ERROR
+#define LOG_LEVEL          LOG_FATAL
 #define MAIN_LOOP_PERIOD   1s
 #define ERROR_CHECK_PERIOD 1s
 #define FLASH_PERIOD       500ms

--- a/Solar/src/main.cpp
+++ b/Solar/src/main.cpp
@@ -8,7 +8,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL        LOG_ERROR
+#define LOG_LEVEL        LOG_FATAL
 #define MAIN_LOOP_PERIOD 1s
 
 SolarCANInterface vehicle_can_interface(CAN_RX, CAN_TX, CAN_STBY);

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,10 +1,9 @@
 {
   "target_overrides": {
     "*": {
-      "target.c_lib": "small",
-      "target.printf_lib": "minimal-printf",
       "platform.stdio-baud-rate": 921600,
-      "platform.stdio-buffered-serial": 1
+      "platform.stdio-buffered-serial": 1,
+      "platform.callback-nontrivial": true
     }
   }
 }


### PR DESCRIPTION
This PR will set `throttle` to 0 if the Motor board has not received an `ECUMotorCommands` message in 100ms. It also changes the default log level to `LOG_FATAL`.  