### PR TITLE
Fix signalFlashHandler

### DIFF
--- a/PowerAux/src/main.cpp
+++ b/PowerAux/src/main.cpp
@@ -32,8 +32,10 @@ void signalFlashHandler() {
                 rightTurnSignal = !rightTurnSignal;
             } else if (flashLSignal & !flashHazards) {
                 leftTurnSignal = !leftTurnSignal;
+                rightTurnSignal = false;
             } else if (flashRSignal & !flashHazards) {
                 rightTurnSignal = !rightTurnSignal;
+                leftTurnSignal = false;
             } else {
                 leftTurnSignal = false;
                 rightTurnSignal = false;


### PR DESCRIPTION
This PR fixes the case where state switches from `flashLSignal` to `flashRSignal` (or vice versa) without intermediate state where both are false.