### PR TITLE
Correct maximum flash size

### DIFF
--- a/Common/boards/uva_solar_car.json
+++ b/Common/boards/uva_solar_car.json
@@ -32,7 +32,7 @@
   "name": "STM32 G473CET6",
   "upload": {
     "maximum_ram_size": 131072,
-    "maximum_size": 524288,
+    "maximum_size": 131072,
     "protocol": "stlink",
     "protocols": [
       "jlink",


### PR DESCRIPTION
This commit corrects the amount of flash memory we have available. Our
chips have 256KB of flash, but only 128KB is available in dual-bank
mode, which we are running. We could enable single-bank mode to increase
the available amount, but we can only use 128KB at the moment.

Prior to this commit, the maximum size was 512KB, likely because we are
using a slightly different MCU than planned.