### PR TITLE
MotorControllerCAN auto-reset

### DIFF
--- a/ECU/src/main.cpp
+++ b/ECU/src/main.cpp
@@ -7,7 +7,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL              LOG_FATAL
+#define LOG_LEVEL              LOG_DEBUG
 #define MAIN_LOOP_PERIOD       1s
 #define MOTOR_THREAD_PERIOD    10ms
 #define POWERAUX_THREAD_PERIOD 10ms

--- a/Motor/lib/include/MotorControllerCANInterface.h
+++ b/Motor/lib/include/MotorControllerCANInterface.h
@@ -1,6 +1,7 @@
 #ifndef MOTOR_CONTROLLER_CAN_INTERFACE_H
 #define MOTOR_CONTROLLER_CAN_INTERFACE_H
 
+#include <mbed.h>
 #include "CANInterface.h"
 #include "MotorControllerCANStructs.h"
 
@@ -15,6 +16,8 @@ class MotorControllerCANInterface : public CANInterface {
 
   private:
     void message_handler() override;
+    Thread bus_status_thread;
+    void check_bus_status();
 };
 
 #endif

--- a/Motor/lib/include/MotorControllerCANInterface.h
+++ b/Motor/lib/include/MotorControllerCANInterface.h
@@ -1,9 +1,9 @@
 #ifndef MOTOR_CONTROLLER_CAN_INTERFACE_H
 #define MOTOR_CONTROLLER_CAN_INTERFACE_H
 
-#include <mbed.h>
 #include "CANInterface.h"
 #include "MotorControllerCANStructs.h"
+#include <mbed.h>
 
 class MotorControllerCANInterface : public CANInterface {
   public:

--- a/Motor/lib/src/MotorControllerCANInterface.cpp
+++ b/Motor/lib/src/MotorControllerCANInterface.cpp
@@ -6,7 +6,8 @@ MotorControllerCANInterface::MotorControllerCANInterface(PinName rd, PinName td,
                                                          PinName standby_pin)
     : CANInterface(rd, td, standby_pin) {
     can.frequency(125000);
-    bus_status_thread.start(callback(this, &MotorControllerCANInterface::check_bus_status));
+    bus_status_thread.start(
+        callback(this, &MotorControllerCANInterface::check_bus_status));
 }
 
 int MotorControllerCANInterface::request_frames(bool power_status_frame,
@@ -70,13 +71,15 @@ void MotorControllerCANInterface::check_bus_status() {
     while (true) {
         int rderror = can.rderror();
         int tderror = can.tderror();
-        
+
         if (rderror >= 128 || tderror >= 128) {
             can.reset();
-            log_warn("MotorControllerCANInterface reset due to RX error %d TX error %d", rderror, tderror);
-        }
-        else {
-            log_debug("MotorControllerCANInterface RX error %d TX error %d", rderror, tderror);
+            log_warn("MotorControllerCANInterface reset due to RX error %d TX "
+                     "error %d",
+                     rderror, tderror);
+        } else {
+            log_debug("MotorControllerCANInterface RX error %d TX error %d",
+                      rderror, tderror);
         }
 
         ThisThread::sleep_for(1s);

--- a/Motor/lib/src/MotorControllerCANInterface.cpp
+++ b/Motor/lib/src/MotorControllerCANInterface.cpp
@@ -79,6 +79,6 @@ void MotorControllerCANInterface::check_bus_status() {
             log_debug("MotorControllerCANInterface RX error %d TX error %d", rderror, tderror);
         }
 
-        ThisThread::sleep_for(5s);
+        ThisThread::sleep_for(1s);
     }
 }

--- a/Motor/lib/src/MotorControllerCANInterface.cpp
+++ b/Motor/lib/src/MotorControllerCANInterface.cpp
@@ -1,10 +1,12 @@
 #include "MotorControllerCANInterface.h"
+#include "ThisThread.h"
 #include "log.h"
 
 MotorControllerCANInterface::MotorControllerCANInterface(PinName rd, PinName td,
                                                          PinName standby_pin)
     : CANInterface(rd, td, standby_pin) {
     can.frequency(125000);
+    bus_status_thread.start(callback(this, &MotorControllerCANInterface::check_bus_status));
 }
 
 int MotorControllerCANInterface::request_frames(bool power_status_frame,
@@ -61,5 +63,22 @@ void MotorControllerCANInterface::message_handler() {
                 handle(&can_struct);
             }
         }
+    }
+}
+
+void MotorControllerCANInterface::check_bus_status() {
+    while (true) {
+        int rderror = can.rderror();
+        int tderror = can.tderror();
+        
+        if (rderror >= 128 || tderror >= 128) {
+            can.reset();
+            log_warn("MotorControllerCANInterface reset due to RX error %d TX error %d", rderror, tderror);
+        }
+        else {
+            log_debug("MotorControllerCANInterface RX error %d TX error %d", rderror, tderror);
+        }
+
+        ThisThread::sleep_for(5s);
     }
 }

--- a/Motor/src/main.cpp
+++ b/Motor/src/main.cpp
@@ -8,7 +8,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL        LOG_FATAL
+#define LOG_LEVEL        LOG_DEBUG
 #define MAIN_LOOP_PERIOD 100ms
 
 EventQueue event_queue(32 * EVENTS_EVENT_SIZE);

--- a/PowerAux/src/main.cpp
+++ b/PowerAux/src/main.cpp
@@ -9,7 +9,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL          LOG_FATAL
+#define LOG_LEVEL          LOG_DEBUG
 #define MAIN_LOOP_PERIOD   1s
 #define ERROR_CHECK_PERIOD 100ms
 #define FLASH_PERIOD       500ms

--- a/Solar/src/main.cpp
+++ b/Solar/src/main.cpp
@@ -7,7 +7,7 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#define LOG_LEVEL        LOG_FATAL
+#define LOG_LEVEL        LOG_DEBUG
 #define MAIN_LOOP_PERIOD 1s
 
 SolarCANInterface vehicle_can_interface(CAN_RX, CAN_TX, CAN_STBY);


### PR DESCRIPTION
This PR automatically resets the motor controller CAN bus if if enters the passive-error state. 